### PR TITLE
Add default credentials to health check

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,6 +31,6 @@ ADD tomcat-users.xml $CATALINA_HOME/conf/tomcat-users.xml
 VOLUME ["$FCREPO_HOME"]
 
 HEALTHCHECK --interval=1m --timeout=5s --start-period=1m --retries=2 \
-  CMD wget -q --spider http://localhost:8080/fcrepo/rest || exit 1
+  CMD wget -q --user fedoraAdmin --password secret3 --spider http://localhost:8080/fcrepo/rest || exit 1
 
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
The health check always fails because of missing credentials. After startup docker reports `Up xx minutes (unhealthy)`:

```
root@6709a12841f4:/usr/local/tomcat# wget --spider http://localhost:8080/fcrepo/rest
Spider mode enabled. Check if remote file exists.
--2020-06-12 12:35:41--  http://localhost:8080/fcrepo/rest
Resolving localhost (localhost)... 127.0.0.1, ::1
Connecting to localhost (localhost)|127.0.0.1|:8080... connected.
HTTP request sent, awaiting response... 401 

Username/Password Authentication Failed.
```

Adding credentials (which should actually be configurable) avoids this:

```
root@6709a12841f4:/usr/local/tomcat# wget --user fedoraAdmin --password secret3 --spider http://localhost:8080/fcrepo/rest
Spider mode enabled. Check if remote file exists.
--2020-06-12 12:36:56--  http://localhost:8080/fcrepo/rest
Resolving localhost (localhost)... 127.0.0.1, ::1
Connecting to localhost (localhost)|127.0.0.1|:8080... connected.
HTTP request sent, awaiting response... 401 
Authentication selected: Basic realm="fcrepo"
Connecting to localhost (localhost)|127.0.0.1|:8080... connected.
HTTP request sent, awaiting response... 200 
Length: unspecified [text/turtle]
Remote file exists.
```